### PR TITLE
Makes fulltext searches that solr does not bork on

### DIFF
--- a/facetedsearch-tools-lib/src/main/java/nl/knaw/huygens/facetedsearch/query/QueryStringBuilder.java
+++ b/facetedsearch-tools-lib/src/main/java/nl/knaw/huygens/facetedsearch/query/QueryStringBuilder.java
@@ -99,20 +99,6 @@ public class QueryStringBuilder implements SolrQueryBuilder {
   }
 
   private String formatTerm(String term, boolean fuzzy) {
-    String cleanedTerm = cleanUpSpecialCharaters(term);
-
-    if (fuzzy) {
-      cleanedTerm = SolrUtils.fuzzy(cleanedTerm);
-    }
-
-    if (cleanedTerm.trim().contains(" ")) {
-      return String.format("(%s)", cleanedTerm);
-    }
-    return cleanedTerm;
-  }
-
-  private String cleanUpSpecialCharaters(String term) {
-
-    return term.replace(":", "");
+    return SolrUtils.escapeFulltextValue(term, fuzzy);
   }
 }

--- a/facetedsearch-tools-lib/src/test/java/nl/knaw/huygens/facetedsearch/query/QueryStringBuilderTest.java
+++ b/facetedsearch-tools-lib/src/test/java/nl/knaw/huygens/facetedsearch/query/QueryStringBuilderTest.java
@@ -134,7 +134,7 @@ public class QueryStringBuilderTest {
 
     instance.build(query, searchParameters);
 
-    assertThat(query.getQuery(), startsWith("+(testSearchField:-test123)"));
+    assertThat(query.getQuery(), startsWith("+(testSearchField:\\-test123~0.7)"));
   }
 
   @Test
@@ -267,19 +267,18 @@ public class QueryStringBuilderTest {
   }
 
   @Test
-  public void testBuildWithTermThatHasColon() {
+  public void testBuildEscapesSpecialCharacters() {
     // setup
-    String termWithColon = "test Test: test test";
-    String cleanedTerm = "test Test test test";
-    searchParameters.setTerm(termWithColon);
-    String fullTextSearchField = "fullTextField";
-    searchParameters.setFullTextSearchFields(Lists.newArrayList(fullTextSearchField));
+    String termSpecialCharacter = "test\" Test: test test";
+    String cleanedTerm = "test\\\" Test\\: test test";
+    searchParameters.setTerm(termSpecialCharacter);
+    searchParameters.setFullTextSearchFields(Lists.newArrayList("fullTextField"));
 
     // action
     instance.build(query, searchParameters);
 
     assertThat(query.getQuery(), containsString(cleanedTerm));
-    assertThat(query.getQuery(), not(containsString(termWithColon)));
+    assertThat(query.getQuery(), not(containsString(termSpecialCharacter)));
 
   }
 

--- a/facetedsearch-tools-services/src/main/java/nl/knaw/huygens/facetedsearch/services/SolrUtils.java
+++ b/facetedsearch-tools-services/src/main/java/nl/knaw/huygens/facetedsearch/services/SolrUtils.java
@@ -1,6 +1,8 @@
 package nl.knaw.huygens.facetedsearch.services;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.*;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang.StringUtils;
@@ -10,33 +12,48 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 
 public class SolrUtils {
-  // Special Lucene characters: + - & | ! ( ) { } [ ] ^ " ~ * ? : \
-  private static final Pattern SPECIAL = Pattern.compile("[+\\-&|!(){}\\[\\]\\^\"~*?:\\\\]");
+  // Special Lucene characters:
+  //this regex matches on
+  // - possibly: an even number of escapes (indicating a sequence of escaped backslashes)
+  // - followed by a lucene character: + - & | ! ( ) { } [ ] ^ " ~ * ? : \
+  //so + will match, \+ will not, \\+ will, \\\+ won't etc.
+  private static final Pattern SPECIAL = Pattern.compile("((?<!\\\\)(\\\\\\\\)*)[-+&|!(){}\\[\\]\\^\"~*?:]");
 
   private SolrUtils() {}
 
-  public static String fuzzy(String text) {
-    if (StringUtils.isBlank(text) || SPECIAL.matcher(text).find()) {
-      return text;
+  /**
+   * Adds fuzzy modifiers to plain text tokens. Will not do anything if it encounters a string that is considered
+   * 'advanced' i.e. a string that contains solr modifiers.
+   * @param fullTextSearchValue
+   * @return
+   */
+  public static String fuzzy(String fullTextSearchValue) {
+    if (StringUtils.isBlank(fullTextSearchValue) || hasUnescapedSolrSpecialCharacters(fullTextSearchValue)) {
+      return fullTextSearchValue;
+    } else {
+      return Arrays.stream(StringUtils.split(fullTextSearchValue))
+        //escaping is not needed because we are only in the else branch if no special character appears in the string
+        //.map(x -> SolrQueryParserBase.escape(x))
+        .map(x -> x.length() < 4 ? x + "~0.5" : x + "~0.7")
+        .collect(Collectors.joining(" AND "));
     }
-    StringBuilder builder = new StringBuilder();
-    String[] terms = StringUtils.split(text);
-    appendTerm(builder, terms[0]);
-    for (int i = 1; i < terms.length; i++) {
-      builder.append(" AND ");
-      appendTerm(builder, terms[i]);
-    }
-    return builder.toString();
   }
 
-  // Method to add the rate the term should match.
-  private static void appendTerm(StringBuilder builder, String term) {
-    builder.append(term);
-    // The rates 0.5 and 0.7 are found to be the best during some experimenting.
-    if (term.length() < 4) {
-      builder.append("~0.5");
+  public static boolean hasUnescapedSolrSpecialCharacters(String str) {
+    return SPECIAL.matcher(str).find();
+  }
+
+  public static String escapeFulltextValue(String fullTextSearchValue, boolean isFuzzySearch) {
+    String cleaned = SolrQueryParserBase.escape(fullTextSearchValue);
+    if (isFuzzySearch) {
+      cleaned = fuzzy(cleaned);
+    }
+    cleaned = cleaned.trim();
+
+    if (cleaned.contains(" ")) {
+      return String.format("(%s)", cleaned);
     } else {
-      builder.append("~0.7");
+      return cleaned;
     }
   }
 

--- a/facetedsearch-tools-services/src/test/java/nl/knaw/huygens/facetedsearch/services/SolrUtilsTest.java
+++ b/facetedsearch-tools-services/src/test/java/nl/knaw/huygens/facetedsearch/services/SolrUtilsTest.java
@@ -11,6 +11,26 @@ import org.junit.Test;
 public class SolrUtilsTest {
 
   @Test
+  public void noSpecialCharactersShouldBeFalse() throws Exception {
+    assertThat(SolrUtils.hasUnescapedSolrSpecialCharacters("aaa")).isFalse();
+  }
+
+  @Test
+  public void aSpecialCharactersShouldBeTrue() throws Exception {
+    assertThat(SolrUtils.hasUnescapedSolrSpecialCharacters("a+aa")).isTrue();
+  }
+
+  @Test
+  public void anEscapedSpecialCharactersShouldBeFalse() throws Exception {
+    assertThat(SolrUtils.hasUnescapedSolrSpecialCharacters("a\\+aa")).isFalse();
+  }
+
+  @Test
+  public void anAlmostEscapedSpecialCharactersShouldBeTrue() throws Exception {
+    assertThat(SolrUtils.hasUnescapedSolrSpecialCharacters("a\\\\+aa")).isTrue();
+  }
+
+  @Test
   public void testEscapeFacetValue() throws Exception {
     String in = "This? is a 'test' (#@!$)";
     String expected = "This\\?\\ is\\ a\\ 'test'\\ \\(#@\\!$\\)";


### PR DESCRIPTION
The Querystring builder now always excapes solr special characters
